### PR TITLE
[HOTT-430] Follow redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (0.2.16)
+    uktt (0.3.0)
       faraday
       nokogiri
       prawn
@@ -12,19 +12,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    mini_portile2 (2.4.0)
+    faraday-net_http (1.0.1)
     multipart-post (2.1.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
-    pdf-core (0.8.1)
-    prawn (2.3.0)
-      pdf-core (~> 0.8.1)
-      ttfunk (~> 1.6)
+    nokogiri (1.11.1-x86_64-linux)
+      racc (~> 1.4)
+    pdf-core (0.9.0)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
+    racc (1.5.2)
     rake (13.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -39,9 +41,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     thor (0.20.3)
-    ttfunk (1.6.2.1)
+    ttfunk (1.7.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Uktt provides a way to work with the UK Trade Tariff API, https://api.trade-tari
 
 ## Installation
 
-The repository is here: __https://gitlab.bitzesty.com/open-source/uktt__
+The repository is here: __https://github.com/TransformCore/uktt/__
 
 Add to your Gemfile:
 
@@ -27,7 +27,7 @@ Set library-wide options using a hash. Here are the current defaults:
 ```ruby
 opts = {
   host: 'http://localhost:3002',  #  use a local frontend server
-  version: 'v1',                  #  `v1` and `v2` are supported
+  version: 'v2',                  #  `v1` and `v2` are supported
   debug: false,                   #  dislays request and response info
   return_json: false              #  returns OpenStruct by default
 }
@@ -292,7 +292,7 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 ## Contributing
 
-Code: https://github.com/bitzesty/uktt.
+Code: https://github.com/TransformCore/uktt.
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday_middleware'
 require 'json'
 
 module Uktt
@@ -8,6 +9,7 @@ module Uktt
       @host = host || API_HOST_LOCAL
       @version = version || API_VERSION
       @conn = Faraday.new(url: @host) do |faraday|
+        faraday.use FaradayMiddleware::FollowRedirects
         faraday.response(:logger) if debug
         faraday.adapter Faraday.default_adapter
       end

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '0.2.16'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -5,8 +5,8 @@ require 'uktt/version'
 Gem::Specification.new do |spec|
   spec.name          = 'uktt'
   spec.version       = Uktt::VERSION
-  spec.authors       = ['Bit Zesty']
-  spec.email         = ['info@bitzesty.com']
+  spec.authors       = ['William Fish', 'Octavian Neguletu']
+  spec.email         = ['trade-tariff-support@enginegroup.com']
 
   spec.summary       = 'A gem to work with the UK Trade Tariff API.'
   # spec.description   = %q{A gem to work with the UK Trade Tariff API.}
@@ -34,10 +34,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday'
+  spec.add_dependency 'nokogiri'
   spec.add_dependency 'prawn'
   spec.add_dependency 'prawn-table'
   spec.add_dependency 'thor', '~> 0.20'
-  spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
**Jira link**

https://transformuk.atlassian.net/browse/HOTT-443

**What**

- [x] Adds redirect support to faraday
 
**Why**

This is needed to make the Uktt client work with the api endpoints that are redirected to the backend (for example, pulling out V2 commodities)

**AC**

- [x] Updated semantic version of gem
- [x] Tested with real invocation