### PR TITLE
Fixes broken urls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,20 @@
 PATH
   remote: .
   specs:
-    uktt (0.3.0)
+    uktt (0.3.1)
       faraday
       faraday_middleware
       nokogiri
       prawn
       prawn-table
+      pry-byebug
       thor
 
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
+    coderay (1.1.2)
     diff-lcs (1.3)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
@@ -20,6 +23,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
+    method_source (1.0.0)
     multipart-post (2.1.1)
     nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
@@ -29,6 +33,12 @@ GEM
       ttfunk (~> 1.7)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     racc (1.5.2)
     rake (13.0.1)
     rspec (3.8.0)

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -17,10 +17,9 @@ module Uktt
     end
 
     def retrieve(resource, return_json = false)
-      response = @conn.get do |request|
-        request.headers['Content-Type'] = 'application/json'
-        request.url([@version, resource].join('/'))
-      end
+      full_url = File.join(@host, 'api', @version, resource)
+      headers  = { 'Content-Type' => 'application/json' }
+      response = @conn.get(full_url, {}, headers)
 
       return response.body if return_json
 

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,0 +1,42 @@
+require 'uktt'
+
+RSpec.describe Uktt::Http do
+  subject(:client) { described_class.new(host, version, debug, conn) }
+
+  let(:version) { 'v2' }
+  let(:debug) { false }
+  let(:conn) { double }
+  let(:response) { double }
+
+  describe '#retrieve' do
+    before do
+      allow(conn).to receive(:get).and_return(response)
+      allow(response).to receive(:body).and_return('{}')
+    end
+
+    let(:expected_headers) { { 'Content-Type' => 'application/json' } }
+    let(:expected_body) { {} } 
+
+    context 'when the host includes xi in the path' do
+      let(:host) { 'http://localhost/xi' }
+      let(:expected_url)  { 'http://localhost/xi/api/v2/commodities/1234567890' } 
+
+      it 'uses the correct full url' do
+        client.retrieve('commodities/1234567890')
+
+        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+      end
+    end
+
+    context 'when the host does not include xi in the path' do
+      let(:host) { 'http://localhost' }
+      let(:expected_url)  { 'http://localhost/api/v2/commodities/1234567890' } 
+
+      it 'uses the correct full url' do
+        client.retrieve('commodities/1234567890')
+
+        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+      end
+    end
+  end
+end

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'prawn'
+  spec.add_dependency 'pry-byebug'
   spec.add_dependency 'prawn-table'
   spec.add_dependency 'thor'
 


### PR DESCRIPTION
When xi is appended to the host

https://dev.trade-tariff.service.gov.uk/xi/

URLs are generated like so:

https://dev.trade-tariff.service.gov.uk/api/v2/xi/v2/commodities/0702000007.json

This is very strange behaviour and probably something odd with the
faraday url generation method.

This change takes control of the url construction and does what we
expect:

https://dev.trade-tariff.service.gov.uk/xi/api/v2/commodities/0702000007.json

These routes are there successfully transformed via the frontend request
forwared and hit the xi backend.