### PR TITLE
[HOT-467] Support jsonapi format as a config option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (0.4.0)
+    uktt (0.5.0)
       faraday
       faraday_middleware
       nokogiri
@@ -13,6 +13,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     byebug (11.1.3)
     coderay (1.1.2)
     diff-lcs (1.3)
@@ -23,6 +25,8 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     method_source (1.0.0)
     multipart-post (2.1.1)
     nokogiri (1.11.1-x86_64-linux)
@@ -39,6 +43,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rake (13.0.1)
     rspec (3.8.0)
@@ -63,6 +68,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  json-schema
+  pry-byebug
   rake (~> 13.0)
   rspec (~> 3.0)
   uktt!

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ gem 'uktt'
 Set library-wide options using a hash. Here are the current defaults:
 ```ruby
 opts = {
-  host: 'http://localhost:3002',  #  use a local frontend server
-  version: 'v2',                  #  `v1` and `v2` are supported
-  debug: false,                   #  dislays request and response info
-  return_json: false              #  returns OpenStruct by default
+  host: 'http://localhost:3002', # use a local frontend server
+  version: 'v2',                 # `v1` and `v2` are supported
+  debug: false,                  # dislays request and response info
+  format: 'ostruct'              # ostruct, json or json api formatted json
 }
 ```
 
@@ -44,12 +44,12 @@ Set options upon instantiation, and change them on the instance by passing-in a 
 > s = Uktt::Section.new
 > s.section_id = '1'
 
-# => #<Uktt::Section @section_id="1", @config={:host=>"http://localhost:3002", :version=>"v1", :debug=>false, :return_json=>false}>
+# => #<Uktt::Section @section_id="1", @config={:host=>"http://localhost:3002", :version=>"v1", :debug=>false, :format=>'ostruct'}>
 
-> s.config = {version: 'v2', return_json: true, section_id: '2'}
+> s.config = {version: 'v2', format: 'json', section_id: '2'}
 > s.inspect
 
-# => #<Uktt::Section @section_id="2", @config={:host=>"http://localhost:3002", :version=>"v2", :debug=>false, :return_json=>true}>
+# => #<Uktt::Section @section_id="2", @config={:host=>"http://localhost:3002", :version=>"v2", :debug=>false, :format=>'json'}>
 
 # NOTE: `Uktt::Section` has accessors. Other objects also have *_id accessors.
 
@@ -59,7 +59,7 @@ Set options upon instantiation, and change them on the instance by passing-in a 
 
 > s.section_id = '3'
 
-# => #<Uktt::Section @section_id="3", @config={:host=>"http://localhost:3002", :version=>"v2", :debug=>false, :return_json=>true}> 
+# => #<Uktt::Section @section_id="3", @config={:host=>"http://localhost:3002", :version=>"v2", :debug=>false, :format=>'json'}> 
 
 ```
 
@@ -71,7 +71,7 @@ Options may be loaded from a YAML configuration file:
   host: http://foo.bar:999
   version: v2
   debug: false
-  return_json: false
+  format: ostruct
 ```
 
 
@@ -80,7 +80,7 @@ Load options from file:
 ```ruby
 > Uktt.configure_with('./uktt.yaml')
 
-# => {"host"=>"http://foo.bar:999", "version"=>"v2", "debug"=>false, "return_json"=>false}
+# => {"host"=>"http://foo.bar:999", "version"=>"v2", "debug"=>false, "format"=>'ostruct'}
 ```
 
 ### Retrieve one object
@@ -92,7 +92,7 @@ Retrieve an object as an OpenStruct, then retrieve it as JSON
 
 # => #<OpenStruct data=#<OpenStruct id="3", type="section", attributes=#<OpenStruct ... >>>
 
-> s.config = {return_json: true}
+> s.config = {format: 'json'}
 > s.retrieve
 
 # => {"data":{"id":"3","type":"section","attributes":{"id": ... }}}

--- a/lib/uktt.rb
+++ b/lib/uktt.rb
@@ -33,7 +33,7 @@ module Uktt
   @config = {
               host: Uktt::Http.api_host, 
               version: Uktt::Http.spec_version, 
-              debug: true,
+              debug: false,
               format: 'ostruct',
               currency: PARENT_CURRENCY
             }

--- a/lib/uktt.rb
+++ b/lib/uktt.rb
@@ -1,20 +1,21 @@
 require 'uktt/version'
-require 'uktt/http'
-require 'uktt/section'
 require 'uktt/chapter'
-require 'uktt/heading'
-require 'uktt/country'
 require 'uktt/commodity'
+require 'uktt/country'
+require 'uktt/heading'
+require 'uktt/http'
 require 'uktt/monetary_exchange_rate'
-require 'uktt/quota'
+require 'uktt/parser'
 require 'uktt/pdf'
+require 'uktt/quota'
+require 'uktt/section'
 
 require 'yaml'
 require 'psych'
 
 module Uktt
-  API_HOST_PROD =       'https://www.trade-tariff.service.gov.uk/api'.freeze
-  API_HOST_LOCAL =      'http://localhost:3002/api'.freeze
+  API_HOST_PROD      = 'https://www.trade-tariff.service.gov.uk'.freeze
+  API_HOST_LOCAL     = 'https://dev.trade-tariff.service.gov.uk'.freeze
   API_VERSION        = 'v1'.freeze
   CHAPTER            = 'chapters'.freeze
   COMMODITY          = 'commodities'.freeze
@@ -32,8 +33,8 @@ module Uktt
   @config = {
               host: Uktt::Http.api_host, 
               version: Uktt::Http.spec_version, 
-              debug: false,
-              return_json: false,
+              debug: true,
+              format: 'ostruct',
               currency: PARENT_CURRENCY
             }
 

--- a/lib/uktt/chapter.rb
+++ b/lib/uktt/chapter.rb
@@ -51,7 +51,7 @@ module Uktt
                      @config[:version], 
                      @config[:debug])
       .retrieve(resource, 
-                @config[:return_json])
+                @config[:format])
     end
   end
 end

--- a/lib/uktt/cli.rb
+++ b/lib/uktt/cli.rb
@@ -19,7 +19,7 @@ module Uktt
                  type: :boolean,
                  desc: 'Show request and response headers, otherwise not shown',
                  banner: true
-    class_option :return_json,
+    class_option :format,
                  aliases: ['-j', '--json'],
                  type: :boolean,
                  desc: 'Request JSON response, otherwise OpenStruct',

--- a/lib/uktt/commodity.rb
+++ b/lib/uktt/commodity.rb
@@ -55,7 +55,7 @@ module Uktt
         @config[:version], 
         @config[:debug])
       .retrieve(resource, 
-        @config[:return_json])
+        @config[:format])
     end
   end
 end

--- a/lib/uktt/country.rb
+++ b/lib/uktt/country.rb
@@ -36,7 +36,7 @@ module Uktt
         @config[:version], 
         @config[:debug])
       .retrieve(resource, 
-        @config[:return_json])
+        @config[:format])
     end
   end
 end

--- a/lib/uktt/heading.rb
+++ b/lib/uktt/heading.rb
@@ -56,7 +56,7 @@ module Uktt
         @config[:version], 
         @config[:debug])
       .retrieve(resource, 
-        @config[:return_json])
+        @config[:format])
     end
   end
 end

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -1,6 +1,5 @@
 require 'faraday'
 require 'faraday_middleware'
-require 'json'
 
 module Uktt
   # An object for handling network requests
@@ -16,14 +15,12 @@ module Uktt
       end
     end
 
-    def retrieve(resource, return_json = false)
+    def retrieve(resource, format = 'ostruct')
       full_url = File.join(@host, 'api', @version, resource)
       headers  = { 'Content-Type' => 'application/json' }
       response = @conn.get(full_url, {}, headers)
 
-      return response.body if return_json
-
-      JSON.parse(response.body, object_class: OpenStruct)
+      Parser.new(response.body, format).parse
     end
 
     class << self

--- a/lib/uktt/monetary_exchange_rate.rb
+++ b/lib/uktt/monetary_exchange_rate.rb
@@ -46,7 +46,7 @@ module Uktt
         @config[:debug]
       ).retrieve(
         resource,
-        @config[:return_json]
+        @config[:format]
       )
     end
   end

--- a/lib/uktt/parser.rb
+++ b/lib/uktt/parser.rb
@@ -1,0 +1,41 @@
+require 'json'
+require_relative 'parser/json_api'
+
+module Uktt
+  class Parser
+    def initialize(body, format)
+      @body = body
+      @format = format
+    end
+
+    def parse
+      return @body if json?
+      return ostruct if ostruct?
+      return json_api if json_api?
+
+      raise ArgumentError, "Specified invalid format #{@format}"
+    end
+
+    private
+
+    def json_api
+      JsonApi.new(@body).parse
+    end
+
+    def ostruct
+      JSON.parse(@body, object_class: OpenStruct)
+    end
+
+    def json?
+      @format == 'json'
+    end
+
+    def ostruct?
+      @format == 'ostruct'
+    end
+
+    def json_api?
+      @format == 'jsonapi'
+    end
+  end
+end

--- a/lib/uktt/parser/json_api.rb
+++ b/lib/uktt/parser/json_api.rb
@@ -1,0 +1,77 @@
+module Uktt
+  class Parser
+    class JsonApi
+      def initialize(body)
+        @body = JSON.parse(body)
+      end
+
+      def parse
+        if data.is_a?(Hash)
+          parse_resource(data)
+        elsif data.is_a?(Array)
+          parse_collection(data)
+        else
+          data
+        end
+      end
+
+      def errors
+        @body['error'] || @body['errors']&.map { |error| error['detail'] }&.join(', ')
+      end
+
+      private
+
+      def data
+        @data = @body['data']
+      end
+
+      def parse_resource(resource)
+        result = {}
+
+        parse_top_level_attributes!(resource, result)
+
+        parse_relationships!(resource['relationships'], result) if resource.key?('relationships')
+
+        result
+      end
+
+      def parse_collection(collection)
+        collection.map do |resource|
+          parse_resource(resource)
+        end
+      end
+
+      def parse_top_level_attributes!(attributes, parent)
+        parent.merge!(attributes['attributes'])
+      end
+
+      def parse_relationships!(relationships, parent)
+        relationships.each do |name, values|
+          parent[name] = if values['data'].is_a?(Array)
+                           values['data'].map do |v|
+                             record = find_included(v['id'], v['type'])
+                             parse_record(record)
+                           end
+                         elsif values['data'].is_a?(Hash)
+                           record = find_included(values['data']['id'], values['data']['type'])
+                           parse_record(record)
+                         else
+                           values['data']
+                         end
+        end
+      end
+
+      def parse_record(record)
+        record_attrs = record['attributes'].clone || {}
+        if record.key?('relationships')
+          parse_relationships!(record['relationships'], record_attrs)
+        end
+        record_attrs
+      end
+
+      def find_included(id, type)
+        @body['included']&.find { |r| r['id'].to_s == id.to_s && r['type'].to_s == type.to_s } || {}
+      end
+    end
+  end
+end

--- a/lib/uktt/quota.rb
+++ b/lib/uktt/quota.rb
@@ -25,7 +25,7 @@ module Uktt
                      @config[:version], 
                      @config[:debug])
       .retrieve(resource, 
-                     @config[:return_json])
+                     @config[:format])
     end
   end
 end

--- a/lib/uktt/section.rb
+++ b/lib/uktt/section.rb
@@ -45,7 +45,7 @@ module Uktt
                      @config[:version], 
                      @config[:debug])
       .retrieve(resource, 
-                     @config[:return_json])
+                     @config[:format])
     end
   end
 end

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/fixtures/commodity.json
+++ b/spec/fixtures/commodity.json
@@ -1,0 +1,9204 @@
+{
+  "data": {
+    "id": "93796",
+    "type": "commodity",
+    "attributes": {
+      "producline_suffix": "80",
+      "description": "Pure-bred breeding animals",
+      "number_indents": 2,
+      "goods_nomenclature_item_id": "0101210000",
+      "bti_url": "https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code",
+      "formatted_description": "Pure-bred breeding animals",
+      "description_plain": "Pure-bred breeding animals",
+      "consigned": false,
+      "consigned_from": null,
+      "basic_duty_rate": "<span>0.00</span> %",
+      "meursing_code": false,
+      "declarable": true
+    },
+    "relationships": {
+      "footnotes": {
+        "data": [
+          {
+            "id": "018",
+            "type": "footnote"
+          },
+          {
+            "id": "701",
+            "type": "footnote"
+          }
+        ]
+      },
+      "section": {
+        "data": {
+          "id": "1",
+          "type": "section"
+        }
+      },
+      "chapter": {
+        "data": {
+          "id": "27623",
+          "type": "chapter"
+        }
+      },
+      "heading": {
+        "data": {
+          "id": "27624",
+          "type": "heading"
+        }
+      },
+      "ancestors": {
+        "data": [
+          {
+            "id": "93797",
+            "type": "commodity"
+          }
+        ]
+      },
+      "import_measures": {
+        "data": [
+          {
+            "id": "20097964",
+            "type": "measure"
+          },
+          {
+            "id": "20000000",
+            "type": "measure"
+          },
+          {
+            "id": "2982599",
+            "type": "measure"
+          },
+          {
+            "id": "-1010362444",
+            "type": "measure"
+          },
+          {
+            "id": "20085280",
+            "type": "measure"
+          },
+          {
+            "id": "20097824",
+            "type": "measure"
+          },
+          {
+            "id": "20125835",
+            "type": "measure"
+          },
+          {
+            "id": "20079764",
+            "type": "measure"
+          },
+          {
+            "id": "20079859",
+            "type": "measure"
+          },
+          {
+            "id": "20079954",
+            "type": "measure"
+          },
+          {
+            "id": "20128794",
+            "type": "measure"
+          },
+          {
+            "id": "20091260",
+            "type": "measure"
+          },
+          {
+            "id": "20079669",
+            "type": "measure"
+          },
+          {
+            "id": "20120631",
+            "type": "measure"
+          },
+          {
+            "id": "20048852",
+            "type": "measure"
+          },
+          {
+            "id": "20098274",
+            "type": "measure"
+          },
+          {
+            "id": "20080049",
+            "type": "measure"
+          },
+          {
+            "id": "20056614",
+            "type": "measure"
+          },
+          {
+            "id": "20072218",
+            "type": "measure"
+          },
+          {
+            "id": "20090143",
+            "type": "measure"
+          },
+          {
+            "id": "20109686",
+            "type": "measure"
+          },
+          {
+            "id": "20079574",
+            "type": "measure"
+          },
+          {
+            "id": "20064704",
+            "type": "measure"
+          },
+          {
+            "id": "20078146",
+            "type": "measure"
+          },
+          {
+            "id": "20076129",
+            "type": "measure"
+          },
+          {
+            "id": "20097204",
+            "type": "measure"
+          },
+          {
+            "id": "20111079",
+            "type": "measure"
+          },
+          {
+            "id": "20119671",
+            "type": "measure"
+          },
+          {
+            "id": "20080334",
+            "type": "measure"
+          },
+          {
+            "id": "20103771",
+            "type": "measure"
+          },
+          {
+            "id": "20125947",
+            "type": "measure"
+          },
+          {
+            "id": "20101931",
+            "type": "measure"
+          },
+          {
+            "id": "20107012",
+            "type": "measure"
+          },
+          {
+            "id": "20080239",
+            "type": "measure"
+          },
+          {
+            "id": "20126145",
+            "type": "measure"
+          },
+          {
+            "id": "20126257",
+            "type": "measure"
+          }
+        ]
+      },
+      "export_measures": {
+        "data": [
+          {
+            "id": "2982599",
+            "type": "measure"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "1",
+      "type": "section",
+      "attributes": {
+        "numeral": "I",
+        "title": "Live animals; animal products",
+        "position": 1,
+        "section_note": "* 1\\. Any reference in this section to a particular genus or species of an animal, except where the context otherwise requires, includes a reference to the young of that genus or species.\r\n* 2\\. Except where the context otherwise requires, throughout the nomenclature any reference to 'dried' products also covers products which have been dehydrated, evaporated or freeze-dried.\r\n"
+      }
+    },
+    {
+      "id": "23",
+      "type": "guide",
+      "attributes": {
+        "title": "Classification of goods",
+        "url": "https://www.gov.uk/government/collections/classification-of-goods"
+      }
+    },
+    {
+      "id": "27623",
+      "type": "chapter",
+      "attributes": {
+        "goods_nomenclature_item_id": "0100000000",
+        "description": "LIVE ANIMALS",
+        "formatted_description": "Live animals",
+        "chapter_note": "* 1\\. This chapter covers all live animals except:\r\n  * (a) fish and crustaceans, molluscs and other aquatic invertebrates, of heading 0301, 0306, 0307 or 0308;\r\n  * (b) cultures of micro-organisms and other products of heading 3002; and\r\n  * (c) animals of heading 9508.\r\n\r\n* 2\\. In this chapter “purebred breeding animal” is defined as in (UK law equivalent to reg 1012/2016)"
+      },
+      "relationships": {
+        "guides": {
+          "data": [
+            {
+              "id": "23",
+              "type": "guide"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "27624",
+      "type": "heading",
+      "attributes": {
+        "goods_nomenclature_item_id": "0101000000",
+        "description": "Live horses, asses, mules and hinnies",
+        "formatted_description": "Live horses, asses, mules and hinnies",
+        "description_plain": "Live horses, asses, mules and hinnies"
+      }
+    },
+    {
+      "id": "93797",
+      "type": "commodity",
+      "attributes": {
+        "producline_suffix": "10",
+        "description": "Horses",
+        "number_indents": 1,
+        "goods_nomenclature_item_id": "0101210000",
+        "formatted_description": "Horses",
+        "description_plain": "Horses"
+      }
+    },
+    {
+      "id": "018",
+      "type": "footnote",
+      "attributes": {
+        "code": "NC018",
+        "description": "Entry under this subheading is subject to the conditions laid down in the relevant provisions of the European Union (see Regulation (EU) 2016/1012 of European Parliament and of the Council (OJ L 171, 29.6.2016, p. 66); Commission Implementing Regulation (EU) 2017/717 (OJ L 109, 26.4.2017, p. 9); Commission Implementing Regulation (EU) 2015/262 (OJ L 59, 3.3.2015, p. 1)).",
+        "formatted_description": "Entry under this subheading is subject to the conditions laid down in the relevant provisions of the European Union (see Regulation (EU) 2016/1012 of European Parliament and of the Council (OJ L 171, 29.6.2016, p. 66); Commission Implementing Regulation (EU) 2017/717 (OJ L 109, 26.4.2017, p. 9); Commission Implementing Regulation (EU) 2015/262 (OJ L 59, 3.3.2015, p. 1))."
+      }
+    },
+    {
+      "id": "701",
+      "type": "footnote",
+      "attributes": {
+        "code": "TN701",
+        "description": "According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br>The prohibition shall not apply in respect of: <br>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement.",
+        "formatted_description": "According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br>The prohibition shall not apply in respect of: <br>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement."
+      }
+    },
+    {
+      "id": "20097964-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "",
+        "formatted_base": ""
+      }
+    },
+    {
+      "id": "410",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Veterinary control",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "410"
+      }
+    },
+    {
+      "id": "C2100270",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2021-01-01",
+        "regulation_code": "C0027/21",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20060183",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "C640",
+        "requirement": "Other certificates: Common Health Entry Document for Animals (CHED-A) (as set out in Part 2, Section A of Annex II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261))",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20060184",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "",
+        "requirement": null,
+        "action": "Import/export not allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "AD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AD",
+        "description": "Andorra",
+        "geographical_area_id": "AD"
+      }
+    },
+    {
+      "id": "AE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AE",
+        "description": "United Arab Emirates",
+        "geographical_area_id": "AE"
+      }
+    },
+    {
+      "id": "AF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AF",
+        "description": "Afghanistan",
+        "geographical_area_id": "AF"
+      }
+    },
+    {
+      "id": "AG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AG",
+        "description": "Antigua and Barbuda",
+        "geographical_area_id": "AG"
+      }
+    },
+    {
+      "id": "AI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AI",
+        "description": "Anguilla",
+        "geographical_area_id": "AI"
+      }
+    },
+    {
+      "id": "AL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AL",
+        "description": "Albania",
+        "geographical_area_id": "AL"
+      }
+    },
+    {
+      "id": "AM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AM",
+        "description": "Armenia",
+        "geographical_area_id": "AM"
+      }
+    },
+    {
+      "id": "AO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AO",
+        "description": "Angola",
+        "geographical_area_id": "AO"
+      }
+    },
+    {
+      "id": "AQ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AQ",
+        "description": "Antarctica",
+        "geographical_area_id": "AQ"
+      }
+    },
+    {
+      "id": "AR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AR",
+        "description": "Argentina",
+        "geographical_area_id": "AR"
+      }
+    },
+    {
+      "id": "AS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AS",
+        "description": "American Samoa",
+        "geographical_area_id": "AS"
+      }
+    },
+    {
+      "id": "AT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AT",
+        "description": "Austria",
+        "geographical_area_id": "AT"
+      }
+    },
+    {
+      "id": "AU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AU",
+        "description": "Australia",
+        "geographical_area_id": "AU"
+      }
+    },
+    {
+      "id": "AW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AW",
+        "description": "Aruba",
+        "geographical_area_id": "AW"
+      }
+    },
+    {
+      "id": "AZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "AZ",
+        "description": "Azerbaijan",
+        "geographical_area_id": "AZ"
+      }
+    },
+    {
+      "id": "BA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BA",
+        "description": "Bosnia and Herzegovina",
+        "geographical_area_id": "BA"
+      }
+    },
+    {
+      "id": "BB",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BB",
+        "description": "Barbados",
+        "geographical_area_id": "BB"
+      }
+    },
+    {
+      "id": "BD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BD",
+        "description": "Bangladesh",
+        "geographical_area_id": "BD"
+      }
+    },
+    {
+      "id": "BE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BE",
+        "description": "Belgium",
+        "geographical_area_id": "BE"
+      }
+    },
+    {
+      "id": "BF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BF",
+        "description": "Burkina Faso",
+        "geographical_area_id": "BF"
+      }
+    },
+    {
+      "id": "BG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BG",
+        "description": "Bulgaria",
+        "geographical_area_id": "BG"
+      }
+    },
+    {
+      "id": "BH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BH",
+        "description": "Bahrain",
+        "geographical_area_id": "BH"
+      }
+    },
+    {
+      "id": "BI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BI",
+        "description": "Burundi",
+        "geographical_area_id": "BI"
+      }
+    },
+    {
+      "id": "BJ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BJ",
+        "description": "Benin",
+        "geographical_area_id": "BJ"
+      }
+    },
+    {
+      "id": "BL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BL",
+        "description": "Saint Barthélemy",
+        "geographical_area_id": "BL"
+      }
+    },
+    {
+      "id": "BM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BM",
+        "description": "Bermuda",
+        "geographical_area_id": "BM"
+      }
+    },
+    {
+      "id": "BN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BN",
+        "description": "Brunei",
+        "geographical_area_id": "BN"
+      }
+    },
+    {
+      "id": "BO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BO",
+        "description": "Bolivia",
+        "geographical_area_id": "BO"
+      }
+    },
+    {
+      "id": "BQ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BQ",
+        "description": "Bonaire, Sint Eustatius and Saba",
+        "geographical_area_id": "BQ"
+      }
+    },
+    {
+      "id": "BR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BR",
+        "description": "Brazil",
+        "geographical_area_id": "BR"
+      }
+    },
+    {
+      "id": "BS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BS",
+        "description": "The Bahamas",
+        "geographical_area_id": "BS"
+      }
+    },
+    {
+      "id": "BT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BT",
+        "description": "Bhutan",
+        "geographical_area_id": "BT"
+      }
+    },
+    {
+      "id": "BV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BV",
+        "description": "Bouvet Island",
+        "geographical_area_id": "BV"
+      }
+    },
+    {
+      "id": "BW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BW",
+        "description": "Botswana",
+        "geographical_area_id": "BW"
+      }
+    },
+    {
+      "id": "BY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BY",
+        "description": "Belarus",
+        "geographical_area_id": "BY"
+      }
+    },
+    {
+      "id": "BZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "BZ",
+        "description": "Belize",
+        "geographical_area_id": "BZ"
+      }
+    },
+    {
+      "id": "CA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CA",
+        "description": "Canada",
+        "geographical_area_id": "CA"
+      }
+    },
+    {
+      "id": "CC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CC",
+        "description": "Cocos (Keeling) Islands",
+        "geographical_area_id": "CC"
+      }
+    },
+    {
+      "id": "CD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CD",
+        "description": "Congo (Democratic Republic)",
+        "geographical_area_id": "CD"
+      }
+    },
+    {
+      "id": "CF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CF",
+        "description": "Central African Republic",
+        "geographical_area_id": "CF"
+      }
+    },
+    {
+      "id": "CG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CG",
+        "description": "Congo",
+        "geographical_area_id": "CG"
+      }
+    },
+    {
+      "id": "CH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CH",
+        "description": "Switzerland",
+        "geographical_area_id": "CH"
+      }
+    },
+    {
+      "id": "CI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CI",
+        "description": "Ivory Coast",
+        "geographical_area_id": "CI"
+      }
+    },
+    {
+      "id": "CK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CK",
+        "description": "Cook Islands",
+        "geographical_area_id": "CK"
+      }
+    },
+    {
+      "id": "CL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CL",
+        "description": "Chile",
+        "geographical_area_id": "CL"
+      }
+    },
+    {
+      "id": "CM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CM",
+        "description": "Cameroon",
+        "geographical_area_id": "CM"
+      }
+    },
+    {
+      "id": "CN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CN",
+        "description": "China",
+        "geographical_area_id": "CN"
+      }
+    },
+    {
+      "id": "CO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CO",
+        "description": "Colombia",
+        "geographical_area_id": "CO"
+      }
+    },
+    {
+      "id": "CR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CR",
+        "description": "Costa Rica",
+        "geographical_area_id": "CR"
+      }
+    },
+    {
+      "id": "CU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CU",
+        "description": "Cuba",
+        "geographical_area_id": "CU"
+      }
+    },
+    {
+      "id": "CV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CV",
+        "description": "Cabo Verde",
+        "geographical_area_id": "CV"
+      }
+    },
+    {
+      "id": "CW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CW",
+        "description": "Curaçao",
+        "geographical_area_id": "CW"
+      }
+    },
+    {
+      "id": "CX",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CX",
+        "description": "Christmas Island",
+        "geographical_area_id": "CX"
+      }
+    },
+    {
+      "id": "CY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CY",
+        "description": "Cyprus",
+        "geographical_area_id": "CY"
+      }
+    },
+    {
+      "id": "CZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "CZ",
+        "description": "Czechia",
+        "geographical_area_id": "CZ"
+      }
+    },
+    {
+      "id": "DE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DE",
+        "description": "Germany",
+        "geographical_area_id": "DE"
+      }
+    },
+    {
+      "id": "DJ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DJ",
+        "description": "Djibouti",
+        "geographical_area_id": "DJ"
+      }
+    },
+    {
+      "id": "DK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DK",
+        "description": "Denmark",
+        "geographical_area_id": "DK"
+      }
+    },
+    {
+      "id": "DM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DM",
+        "description": "Dominica",
+        "geographical_area_id": "DM"
+      }
+    },
+    {
+      "id": "DO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DO",
+        "description": "Dominican Republic",
+        "geographical_area_id": "DO"
+      }
+    },
+    {
+      "id": "DZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "DZ",
+        "description": "Algeria",
+        "geographical_area_id": "DZ"
+      }
+    },
+    {
+      "id": "EC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "EC",
+        "description": "Ecuador",
+        "geographical_area_id": "EC"
+      }
+    },
+    {
+      "id": "EE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "EE",
+        "description": "Estonia",
+        "geographical_area_id": "EE"
+      }
+    },
+    {
+      "id": "EG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "EG",
+        "description": "Egypt",
+        "geographical_area_id": "EG"
+      }
+    },
+    {
+      "id": "EH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "EH",
+        "description": "Western Sahara",
+        "geographical_area_id": "EH"
+      }
+    },
+    {
+      "id": "ER",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ER",
+        "description": "Eritrea",
+        "geographical_area_id": "ER"
+      }
+    },
+    {
+      "id": "ES",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ES",
+        "description": "Spain",
+        "geographical_area_id": "ES"
+      }
+    },
+    {
+      "id": "ET",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ET",
+        "description": "Ethiopia",
+        "geographical_area_id": "ET"
+      }
+    },
+    {
+      "id": "EU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "EU",
+        "description": "European Union",
+        "geographical_area_id": "EU"
+      }
+    },
+    {
+      "id": "FI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FI",
+        "description": "Finland",
+        "geographical_area_id": "FI"
+      }
+    },
+    {
+      "id": "FJ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FJ",
+        "description": "Fiji",
+        "geographical_area_id": "FJ"
+      }
+    },
+    {
+      "id": "FK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FK",
+        "description": "Falkland Islands",
+        "geographical_area_id": "FK"
+      }
+    },
+    {
+      "id": "FM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FM",
+        "description": "Micronesia",
+        "geographical_area_id": "FM"
+      }
+    },
+    {
+      "id": "FO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FO",
+        "description": "Faroe Islands",
+        "geographical_area_id": "FO"
+      }
+    },
+    {
+      "id": "FR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "FR",
+        "description": "France",
+        "geographical_area_id": "FR"
+      }
+    },
+    {
+      "id": "GA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GA",
+        "description": "Gabon",
+        "geographical_area_id": "GA"
+      }
+    },
+    {
+      "id": "GB",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GB",
+        "description": "United Kingdom",
+        "geographical_area_id": "GB"
+      }
+    },
+    {
+      "id": "GD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GD",
+        "description": "Grenada",
+        "geographical_area_id": "GD"
+      }
+    },
+    {
+      "id": "GE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GE",
+        "description": "Georgia",
+        "geographical_area_id": "GE"
+      }
+    },
+    {
+      "id": "GH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GH",
+        "description": "Ghana",
+        "geographical_area_id": "GH"
+      }
+    },
+    {
+      "id": "GI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GI",
+        "description": "Gibraltar",
+        "geographical_area_id": "GI"
+      }
+    },
+    {
+      "id": "GL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GL",
+        "description": "Greenland",
+        "geographical_area_id": "GL"
+      }
+    },
+    {
+      "id": "GM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GM",
+        "description": "The Gambia",
+        "geographical_area_id": "GM"
+      }
+    },
+    {
+      "id": "GN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GN",
+        "description": "Guinea",
+        "geographical_area_id": "GN"
+      }
+    },
+    {
+      "id": "GQ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GQ",
+        "description": "Equatorial Guinea",
+        "geographical_area_id": "GQ"
+      }
+    },
+    {
+      "id": "GR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GR",
+        "description": "Greece",
+        "geographical_area_id": "GR"
+      }
+    },
+    {
+      "id": "GS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GS",
+        "description": "South Georgia and South Sandwich Islands",
+        "geographical_area_id": "GS"
+      }
+    },
+    {
+      "id": "GT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GT",
+        "description": "Guatemala",
+        "geographical_area_id": "GT"
+      }
+    },
+    {
+      "id": "GU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GU",
+        "description": "Guam",
+        "geographical_area_id": "GU"
+      }
+    },
+    {
+      "id": "GW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GW",
+        "description": "Guinea-Bissau",
+        "geographical_area_id": "GW"
+      }
+    },
+    {
+      "id": "GY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "GY",
+        "description": "Guyana",
+        "geographical_area_id": "GY"
+      }
+    },
+    {
+      "id": "HK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HK",
+        "description": "Hong Kong",
+        "geographical_area_id": "HK"
+      }
+    },
+    {
+      "id": "HM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HM",
+        "description": "Heard Island and McDonald Islands",
+        "geographical_area_id": "HM"
+      }
+    },
+    {
+      "id": "HN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HN",
+        "description": "Honduras",
+        "geographical_area_id": "HN"
+      }
+    },
+    {
+      "id": "HR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HR",
+        "description": "Croatia",
+        "geographical_area_id": "HR"
+      }
+    },
+    {
+      "id": "HT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HT",
+        "description": "Haiti",
+        "geographical_area_id": "HT"
+      }
+    },
+    {
+      "id": "HU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "HU",
+        "description": "Hungary",
+        "geographical_area_id": "HU"
+      }
+    },
+    {
+      "id": "ID",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ID",
+        "description": "Indonesia",
+        "geographical_area_id": "ID"
+      }
+    },
+    {
+      "id": "IE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IE",
+        "description": "Ireland",
+        "geographical_area_id": "IE"
+      }
+    },
+    {
+      "id": "IL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IL",
+        "description": "Israel",
+        "geographical_area_id": "IL"
+      }
+    },
+    {
+      "id": "IN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IN",
+        "description": "India",
+        "geographical_area_id": "IN"
+      }
+    },
+    {
+      "id": "IO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IO",
+        "description": "British Indian Ocean Territory",
+        "geographical_area_id": "IO"
+      }
+    },
+    {
+      "id": "IQ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IQ",
+        "description": "Iraq",
+        "geographical_area_id": "IQ"
+      }
+    },
+    {
+      "id": "IR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IR",
+        "description": "Iran",
+        "geographical_area_id": "IR"
+      }
+    },
+    {
+      "id": "IS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IS",
+        "description": "Iceland",
+        "geographical_area_id": "IS"
+      }
+    },
+    {
+      "id": "IT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "IT",
+        "description": "Italy",
+        "geographical_area_id": "IT"
+      }
+    },
+    {
+      "id": "JM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "JM",
+        "description": "Jamaica",
+        "geographical_area_id": "JM"
+      }
+    },
+    {
+      "id": "JO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "JO",
+        "description": "Jordan",
+        "geographical_area_id": "JO"
+      }
+    },
+    {
+      "id": "JP",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "JP",
+        "description": "Japan",
+        "geographical_area_id": "JP"
+      }
+    },
+    {
+      "id": "KE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KE",
+        "description": "Kenya",
+        "geographical_area_id": "KE"
+      }
+    },
+    {
+      "id": "KG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KG",
+        "description": "Kyrgyzstan",
+        "geographical_area_id": "KG"
+      }
+    },
+    {
+      "id": "KH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KH",
+        "description": "Cambodia",
+        "geographical_area_id": "KH"
+      }
+    },
+    {
+      "id": "KI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KI",
+        "description": "Kiribati",
+        "geographical_area_id": "KI"
+      }
+    },
+    {
+      "id": "KM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KM",
+        "description": "Comoros",
+        "geographical_area_id": "KM"
+      }
+    },
+    {
+      "id": "KN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KN",
+        "description": "St Kitts and Nevis",
+        "geographical_area_id": "KN"
+      }
+    },
+    {
+      "id": "KP",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KP",
+        "description": "North Korea",
+        "geographical_area_id": "KP"
+      }
+    },
+    {
+      "id": "KR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KR",
+        "description": "South Korea",
+        "geographical_area_id": "KR"
+      }
+    },
+    {
+      "id": "KW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KW",
+        "description": "Kuwait",
+        "geographical_area_id": "KW"
+      }
+    },
+    {
+      "id": "KY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KY",
+        "description": "Cayman Islands",
+        "geographical_area_id": "KY"
+      }
+    },
+    {
+      "id": "KZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "KZ",
+        "description": "Kazakhstan",
+        "geographical_area_id": "KZ"
+      }
+    },
+    {
+      "id": "LA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LA",
+        "description": "Laos",
+        "geographical_area_id": "LA"
+      }
+    },
+    {
+      "id": "LB",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LB",
+        "description": "Lebanon",
+        "geographical_area_id": "LB"
+      }
+    },
+    {
+      "id": "LC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LC",
+        "description": "St Lucia",
+        "geographical_area_id": "LC"
+      }
+    },
+    {
+      "id": "LI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LI",
+        "description": "Liechtenstein",
+        "geographical_area_id": "LI"
+      }
+    },
+    {
+      "id": "LK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LK",
+        "description": "Sri Lanka",
+        "geographical_area_id": "LK"
+      }
+    },
+    {
+      "id": "LR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LR",
+        "description": "Liberia",
+        "geographical_area_id": "LR"
+      }
+    },
+    {
+      "id": "LS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LS",
+        "description": "Lesotho",
+        "geographical_area_id": "LS"
+      }
+    },
+    {
+      "id": "LT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LT",
+        "description": "Lithuania",
+        "geographical_area_id": "LT"
+      }
+    },
+    {
+      "id": "LU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LU",
+        "description": "Luxembourg",
+        "geographical_area_id": "LU"
+      }
+    },
+    {
+      "id": "LV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LV",
+        "description": "Latvia",
+        "geographical_area_id": "LV"
+      }
+    },
+    {
+      "id": "LY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "LY",
+        "description": "Libya",
+        "geographical_area_id": "LY"
+      }
+    },
+    {
+      "id": "MA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MA",
+        "description": "Morocco",
+        "geographical_area_id": "MA"
+      }
+    },
+    {
+      "id": "MD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MD",
+        "description": "Moldova",
+        "geographical_area_id": "MD"
+      }
+    },
+    {
+      "id": "ME",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ME",
+        "description": "Montenegro",
+        "geographical_area_id": "ME"
+      }
+    },
+    {
+      "id": "MG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MG",
+        "description": "Madagascar",
+        "geographical_area_id": "MG"
+      }
+    },
+    {
+      "id": "MH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MH",
+        "description": "Marshall Islands",
+        "geographical_area_id": "MH"
+      }
+    },
+    {
+      "id": "MK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MK",
+        "description": "North Macedonia",
+        "geographical_area_id": "MK"
+      }
+    },
+    {
+      "id": "ML",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ML",
+        "description": "Mali",
+        "geographical_area_id": "ML"
+      }
+    },
+    {
+      "id": "MM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MM",
+        "description": "Myanmar (Burma)",
+        "geographical_area_id": "MM"
+      }
+    },
+    {
+      "id": "MN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MN",
+        "description": "Mongolia",
+        "geographical_area_id": "MN"
+      }
+    },
+    {
+      "id": "MO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MO",
+        "description": "Macao",
+        "geographical_area_id": "MO"
+      }
+    },
+    {
+      "id": "MP",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MP",
+        "description": "Northern Mariana Islands",
+        "geographical_area_id": "MP"
+      }
+    },
+    {
+      "id": "MR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MR",
+        "description": "Mauritania",
+        "geographical_area_id": "MR"
+      }
+    },
+    {
+      "id": "MS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MS",
+        "description": "Montserrat",
+        "geographical_area_id": "MS"
+      }
+    },
+    {
+      "id": "MT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MT",
+        "description": "Malta",
+        "geographical_area_id": "MT"
+      }
+    },
+    {
+      "id": "MU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MU",
+        "description": "Mauritius",
+        "geographical_area_id": "MU"
+      }
+    },
+    {
+      "id": "MV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MV",
+        "description": "Maldives",
+        "geographical_area_id": "MV"
+      }
+    },
+    {
+      "id": "MW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MW",
+        "description": "Malawi",
+        "geographical_area_id": "MW"
+      }
+    },
+    {
+      "id": "MX",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MX",
+        "description": "Mexico",
+        "geographical_area_id": "MX"
+      }
+    },
+    {
+      "id": "MY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MY",
+        "description": "Malaysia",
+        "geographical_area_id": "MY"
+      }
+    },
+    {
+      "id": "MZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "MZ",
+        "description": "Mozambique",
+        "geographical_area_id": "MZ"
+      }
+    },
+    {
+      "id": "NA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NA",
+        "description": "Namibia",
+        "geographical_area_id": "NA"
+      }
+    },
+    {
+      "id": "NC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NC",
+        "description": "New Caledonia",
+        "geographical_area_id": "NC"
+      }
+    },
+    {
+      "id": "NE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NE",
+        "description": "Niger",
+        "geographical_area_id": "NE"
+      }
+    },
+    {
+      "id": "NF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NF",
+        "description": "Norfolk Island",
+        "geographical_area_id": "NF"
+      }
+    },
+    {
+      "id": "NG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NG",
+        "description": "Nigeria",
+        "geographical_area_id": "NG"
+      }
+    },
+    {
+      "id": "NI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NI",
+        "description": "Nicaragua",
+        "geographical_area_id": "NI"
+      }
+    },
+    {
+      "id": "NL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NL",
+        "description": "Netherlands",
+        "geographical_area_id": "NL"
+      }
+    },
+    {
+      "id": "NO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NO",
+        "description": "Norway",
+        "geographical_area_id": "NO"
+      }
+    },
+    {
+      "id": "NP",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NP",
+        "description": "Nepal",
+        "geographical_area_id": "NP"
+      }
+    },
+    {
+      "id": "NR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NR",
+        "description": "Nauru",
+        "geographical_area_id": "NR"
+      }
+    },
+    {
+      "id": "NU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NU",
+        "description": "Niue",
+        "geographical_area_id": "NU"
+      }
+    },
+    {
+      "id": "NZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "NZ",
+        "description": "New Zealand",
+        "geographical_area_id": "NZ"
+      }
+    },
+    {
+      "id": "OM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "OM",
+        "description": "Oman",
+        "geographical_area_id": "OM"
+      }
+    },
+    {
+      "id": "PA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PA",
+        "description": "Panama",
+        "geographical_area_id": "PA"
+      }
+    },
+    {
+      "id": "PE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PE",
+        "description": "Peru",
+        "geographical_area_id": "PE"
+      }
+    },
+    {
+      "id": "PF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PF",
+        "description": "French Polynesia",
+        "geographical_area_id": "PF"
+      }
+    },
+    {
+      "id": "PG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PG",
+        "description": "Papua New Guinea",
+        "geographical_area_id": "PG"
+      }
+    },
+    {
+      "id": "PH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PH",
+        "description": "Philippines",
+        "geographical_area_id": "PH"
+      }
+    },
+    {
+      "id": "PK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PK",
+        "description": "Pakistan",
+        "geographical_area_id": "PK"
+      }
+    },
+    {
+      "id": "PL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PL",
+        "description": "Poland",
+        "geographical_area_id": "PL"
+      }
+    },
+    {
+      "id": "PM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PM",
+        "description": "Saint Pierre and Miquelon",
+        "geographical_area_id": "PM"
+      }
+    },
+    {
+      "id": "PN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PN",
+        "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+        "geographical_area_id": "PN"
+      }
+    },
+    {
+      "id": "PS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PS",
+        "description": "Occupied Palestinian Territories",
+        "geographical_area_id": "PS"
+      }
+    },
+    {
+      "id": "PT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PT",
+        "description": "Portugal",
+        "geographical_area_id": "PT"
+      }
+    },
+    {
+      "id": "PW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PW",
+        "description": "Palau",
+        "geographical_area_id": "PW"
+      }
+    },
+    {
+      "id": "PY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "PY",
+        "description": "Paraguay",
+        "geographical_area_id": "PY"
+      }
+    },
+    {
+      "id": "QA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QA",
+        "description": "Qatar",
+        "geographical_area_id": "QA"
+      }
+    },
+    {
+      "id": "QP",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QP",
+        "description": "High seas (Maritime domain outside of territorial waters)",
+        "geographical_area_id": "QP"
+      }
+    },
+    {
+      "id": "QQ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QQ",
+        "description": "Stores and provisions",
+        "geographical_area_id": "QQ"
+      }
+    },
+    {
+      "id": "QS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QS",
+        "description": "Stores and provisions within the framework of trade with Third Countries",
+        "geographical_area_id": "QS"
+      }
+    },
+    {
+      "id": "QU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QU",
+        "description": "Countries and territories not specified",
+        "geographical_area_id": "QU"
+      }
+    },
+    {
+      "id": "QW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "QW",
+        "description": "Countries and territories not specified within the framework of trade with third countries",
+        "geographical_area_id": "QW"
+      }
+    },
+    {
+      "id": "RO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "RO",
+        "description": "Romania",
+        "geographical_area_id": "RO"
+      }
+    },
+    {
+      "id": "RU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "RU",
+        "description": "Russia",
+        "geographical_area_id": "RU"
+      }
+    },
+    {
+      "id": "RW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "RW",
+        "description": "Rwanda",
+        "geographical_area_id": "RW"
+      }
+    },
+    {
+      "id": "SA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SA",
+        "description": "Saudi Arabia",
+        "geographical_area_id": "SA"
+      }
+    },
+    {
+      "id": "SB",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SB",
+        "description": "Solomon Islands",
+        "geographical_area_id": "SB"
+      }
+    },
+    {
+      "id": "SC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SC",
+        "description": "Seychelles",
+        "geographical_area_id": "SC"
+      }
+    },
+    {
+      "id": "SD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SD",
+        "description": "Sudan",
+        "geographical_area_id": "SD"
+      }
+    },
+    {
+      "id": "SE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SE",
+        "description": "Sweden",
+        "geographical_area_id": "SE"
+      }
+    },
+    {
+      "id": "SG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SG",
+        "description": "Singapore",
+        "geographical_area_id": "SG"
+      }
+    },
+    {
+      "id": "SH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SH",
+        "description": "Saint Helena, Ascension and Tristan da Cunha",
+        "geographical_area_id": "SH"
+      }
+    },
+    {
+      "id": "SI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SI",
+        "description": "Slovenia",
+        "geographical_area_id": "SI"
+      }
+    },
+    {
+      "id": "SK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SK",
+        "description": "Slovakia",
+        "geographical_area_id": "SK"
+      }
+    },
+    {
+      "id": "SL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SL",
+        "description": "Sierra Leone",
+        "geographical_area_id": "SL"
+      }
+    },
+    {
+      "id": "SM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SM",
+        "description": "San Marino",
+        "geographical_area_id": "SM"
+      }
+    },
+    {
+      "id": "SN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SN",
+        "description": "Senegal",
+        "geographical_area_id": "SN"
+      }
+    },
+    {
+      "id": "SO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SO",
+        "description": "Somalia",
+        "geographical_area_id": "SO"
+      }
+    },
+    {
+      "id": "SR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SR",
+        "description": "Suriname",
+        "geographical_area_id": "SR"
+      }
+    },
+    {
+      "id": "SS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SS",
+        "description": "South Sudan",
+        "geographical_area_id": "SS"
+      }
+    },
+    {
+      "id": "ST",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ST",
+        "description": "Sao Tome and Principe",
+        "geographical_area_id": "ST"
+      }
+    },
+    {
+      "id": "SV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SV",
+        "description": "El Salvador",
+        "geographical_area_id": "SV"
+      }
+    },
+    {
+      "id": "SX",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SX",
+        "description": "Sint Maarten (Dutch part)",
+        "geographical_area_id": "SX"
+      }
+    },
+    {
+      "id": "SY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SY",
+        "description": "Syria",
+        "geographical_area_id": "SY"
+      }
+    },
+    {
+      "id": "SZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "SZ",
+        "description": "Eswatini",
+        "geographical_area_id": "SZ"
+      }
+    },
+    {
+      "id": "TC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TC",
+        "description": "Turks and Caicos Islands",
+        "geographical_area_id": "TC"
+      }
+    },
+    {
+      "id": "TD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TD",
+        "description": "Chad",
+        "geographical_area_id": "TD"
+      }
+    },
+    {
+      "id": "TF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TF",
+        "description": "French Southern Territories",
+        "geographical_area_id": "TF"
+      }
+    },
+    {
+      "id": "TG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TG",
+        "description": "Togo",
+        "geographical_area_id": "TG"
+      }
+    },
+    {
+      "id": "TH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TH",
+        "description": "Thailand",
+        "geographical_area_id": "TH"
+      }
+    },
+    {
+      "id": "TJ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TJ",
+        "description": "Tajikistan",
+        "geographical_area_id": "TJ"
+      }
+    },
+    {
+      "id": "TK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TK",
+        "description": "Tokelau",
+        "geographical_area_id": "TK"
+      }
+    },
+    {
+      "id": "TL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TL",
+        "description": "East Timor",
+        "geographical_area_id": "TL"
+      }
+    },
+    {
+      "id": "TM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TM",
+        "description": "Turkmenistan",
+        "geographical_area_id": "TM"
+      }
+    },
+    {
+      "id": "TN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TN",
+        "description": "Tunisia",
+        "geographical_area_id": "TN"
+      }
+    },
+    {
+      "id": "TO",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TO",
+        "description": "Tonga",
+        "geographical_area_id": "TO"
+      }
+    },
+    {
+      "id": "TR",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TR",
+        "description": "Turkey",
+        "geographical_area_id": "TR"
+      }
+    },
+    {
+      "id": "TT",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TT",
+        "description": "Trinidad and Tobago",
+        "geographical_area_id": "TT"
+      }
+    },
+    {
+      "id": "TV",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TV",
+        "description": "Tuvalu",
+        "geographical_area_id": "TV"
+      }
+    },
+    {
+      "id": "TW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TW",
+        "description": "Taiwan",
+        "geographical_area_id": "TW"
+      }
+    },
+    {
+      "id": "TZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "TZ",
+        "description": "Tanzania",
+        "geographical_area_id": "TZ"
+      }
+    },
+    {
+      "id": "UA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "UA",
+        "description": "Ukraine",
+        "geographical_area_id": "UA"
+      }
+    },
+    {
+      "id": "UG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "UG",
+        "description": "Uganda",
+        "geographical_area_id": "UG"
+      }
+    },
+    {
+      "id": "UM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "UM",
+        "description": "United States Minor Outlying Islands",
+        "geographical_area_id": "UM"
+      }
+    },
+    {
+      "id": "US",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "US",
+        "description": "United States",
+        "geographical_area_id": "US"
+      }
+    },
+    {
+      "id": "UY",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "UY",
+        "description": "Uruguay",
+        "geographical_area_id": "UY"
+      }
+    },
+    {
+      "id": "UZ",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "UZ",
+        "description": "Uzbekistan",
+        "geographical_area_id": "UZ"
+      }
+    },
+    {
+      "id": "VA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VA",
+        "description": "Vatican City",
+        "geographical_area_id": "VA"
+      }
+    },
+    {
+      "id": "VC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VC",
+        "description": "St Vincent",
+        "geographical_area_id": "VC"
+      }
+    },
+    {
+      "id": "VE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VE",
+        "description": "Venezuela",
+        "geographical_area_id": "VE"
+      }
+    },
+    {
+      "id": "VG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VG",
+        "description": "British Virgin Islands",
+        "geographical_area_id": "VG"
+      }
+    },
+    {
+      "id": "VI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VI",
+        "description": "United States Virgin Islands",
+        "geographical_area_id": "VI"
+      }
+    },
+    {
+      "id": "VN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VN",
+        "description": "Vietnam",
+        "geographical_area_id": "VN"
+      }
+    },
+    {
+      "id": "VU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "VU",
+        "description": "Vanuatu",
+        "geographical_area_id": "VU"
+      }
+    },
+    {
+      "id": "WF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "WF",
+        "description": "Wallis and Futuna",
+        "geographical_area_id": "WF"
+      }
+    },
+    {
+      "id": "WS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "WS",
+        "description": "Samoa",
+        "geographical_area_id": "WS"
+      }
+    },
+    {
+      "id": "XC",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "XC",
+        "description": "Ceuta",
+        "geographical_area_id": "XC"
+      }
+    },
+    {
+      "id": "XK",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "XK",
+        "description": "Kosovo",
+        "geographical_area_id": "XK"
+      }
+    },
+    {
+      "id": "XL",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "XL",
+        "description": "Melilla",
+        "geographical_area_id": "XL"
+      }
+    },
+    {
+      "id": "XS",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "XS",
+        "description": "Serbia",
+        "geographical_area_id": "XS"
+      }
+    },
+    {
+      "id": "YE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "YE",
+        "description": "Yemen",
+        "geographical_area_id": "YE"
+      }
+    },
+    {
+      "id": "ZA",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZA",
+        "description": "South Africa",
+        "geographical_area_id": "ZA"
+      }
+    },
+    {
+      "id": "ZB",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZB",
+        "description": "Belgian Continental Shelf",
+        "geographical_area_id": "ZB"
+      }
+    },
+    {
+      "id": "ZD",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZD",
+        "description": "Danish Continental Shelf",
+        "geographical_area_id": "ZD"
+      }
+    },
+    {
+      "id": "ZE",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZE",
+        "description": "Irish Continental Shelf",
+        "geographical_area_id": "ZE"
+      }
+    },
+    {
+      "id": "ZF",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZF",
+        "description": "French Continental Shelf",
+        "geographical_area_id": "ZF"
+      }
+    },
+    {
+      "id": "ZG",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZG",
+        "description": "German Continental Shelf",
+        "geographical_area_id": "ZG"
+      }
+    },
+    {
+      "id": "ZH",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZH",
+        "description": "Netherlands Continental Shelf",
+        "geographical_area_id": "ZH"
+      }
+    },
+    {
+      "id": "ZM",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZM",
+        "description": "Zambia",
+        "geographical_area_id": "ZM"
+      }
+    },
+    {
+      "id": "ZN",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZN",
+        "description": "Norwegian Continental Shelf",
+        "geographical_area_id": "ZN"
+      }
+    },
+    {
+      "id": "ZU",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZU",
+        "description": "United Kingdom Continental Shelf",
+        "geographical_area_id": "ZU"
+      }
+    },
+    {
+      "id": "ZW",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "ZW",
+        "description": "Zimbabwe",
+        "geographical_area_id": "ZW"
+      }
+    },
+    {
+      "id": "1008",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1008",
+        "description": "All third countries",
+        "geographical_area_id": "1008"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ER",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ES",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ET",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ID",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ME",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ML",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "OM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ST",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "US",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "WF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "WS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "YE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZW",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "CD625",
+      "type": "footnote",
+      "attributes": {
+        "code": "CD625",
+        "description": "The entry into free circulation of live animals is subject to the presentation of a Common Health Entry Document for live animals (CHED-A) in accordance with the conditions laid down in article 40 of the Commission Implementing Regulation (EU) 2019/1715 of 30 September 2019 laying down rules for the functioning of the information management system for official controls and its system components (‘the IMSOC Regulation’).",
+        "formatted_description": "The entry into free circulation of live animals is subject to the presentation of a Common Health Entry Document for live animals (CHED-A) in accordance with the conditions laid down in article 40 of the Commission Implementing Regulation (EU) 2019/1715 of 30 September 2019 laying down rules for the functioning of the information management system for official controls and its system components (‘the IMSOC Regulation’)."
+      }
+    },
+    {
+      "id": "20097964",
+      "type": "measure",
+      "attributes": {
+        "id": 20097964,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20097964-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "410",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100270",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+            {
+              "id": "20060183",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20060184",
+              "type": "measure_condition"
+            }
+          ]
+        },
+        "measure_components": {
+          "data": [
+
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1008",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+            {
+              "id": "CD625",
+              "type": "footnote"
+            }
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20000000-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "103",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Third country duty",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "103"
+      }
+    },
+    {
+      "id": "C2100001",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2021-01-01",
+        "regulation_code": "C0000/21",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20000000-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "1011",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ER",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ES",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ET",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ID",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ME",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ML",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "OM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QQ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "QW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ST",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SX",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "US",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "WF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "WS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "XS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "YE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZW",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20000000",
+      "type": "measure",
+      "attributes": {
+        "id": 20000000,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20000000-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "103",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100001",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20000000-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1011",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "2982599-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "p/st",
+        "formatted_base": "<abbr title='Number of items'>p/st</abbr>"
+      }
+    },
+    {
+      "id": "109",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Supplementary unit",
+        "national": null,
+        "measure_type_series_id": "O",
+        "id": "109"
+      }
+    },
+    {
+      "id": "R8726581",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "1988-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "L 256",
+        "officialjournal_page": null,
+        "published_date": "1987-09-07",
+        "regulation_code": "R2658/87",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D31987R2658*,DN-old%3D31987R2658*&DTC=false&type=advanced"
+      }
+    },
+    {
+      "id": "2982599-99",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "99",
+        "duty_amount": null,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": "NAR",
+        "duty_expression_description": "Supplementary unit",
+        "duty_expression_abbreviation": "UNSUP",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "2982599",
+      "type": "measure",
+      "attributes": {
+        "id": 2982599,
+        "origin": "eu",
+        "effective_start_date": "2008-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "2982599-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "109",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "R8726581",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "2982599-99",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1011",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "-1010362444-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "20.00 %",
+        "formatted_base": "<span>20.00</span> %"
+      }
+    },
+    {
+      "id": "305",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Value added tax",
+        "national": null,
+        "measure_type_series_id": "P",
+        "id": "305"
+      }
+    },
+    {
+      "id": "V1970ATS",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "1970-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": null,
+        "officialjournal_page": null,
+        "published_date": "1970-01-01",
+        "regulation_code": "V70AT/19",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D32019V70AT*,DN-old%3D32019V70AT*&DTC=false&type=advanced"
+      }
+    },
+    {
+      "id": "-1010362444-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 20.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "03020",
+      "type": "footnote",
+      "attributes": {
+        "code": "03020",
+        "description": "UK VAT standard rate",
+        "formatted_description": "UK VAT standard rate"
+      }
+    },
+    {
+      "id": "-1010362444",
+      "type": "measure",
+      "attributes": {
+        "id": -1010362444,
+        "origin": "uk",
+        "effective_start_date": "2020-06-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": true
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "-1010362444-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "305",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "V1970ATS",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "-1010362444-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1011",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+            {
+              "id": "03020",
+              "type": "footnote"
+            }
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20085280-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "",
+        "formatted_base": ""
+      }
+    },
+    {
+      "id": "350",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Animal Health Certificate",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "350"
+      }
+    },
+    {
+      "id": "C2100009",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2021-01-01",
+        "regulation_code": "C0000/21",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20052305",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "9120",
+        "requirement": "National Document: Importation of animal pathogens Licence under the Importation of Animal pathogens Order 1980 (IAPO)",
+        "action": "Entry into free circulation allowed",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20052306",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "",
+        "requirement": null,
+        "action": "The entry into free circulation is not allowed",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "PR003",
+      "type": "footnote",
+      "attributes": {
+        "code": "PR003",
+        "description": "Contact Details for lead Government Department are as follows: <P> <P>Rabies &amp; Hares - Animal Health Certificate Animal - Rabies Pathogens, Hares <P> <P>Animal Health &amp; Veterinary Laboratories Agency</P><P>Hadrian House</P><P>Wavell Drive</P><P>Rosehill</P><P>Carlisle</P><P>CA1 2TB</P><P>Telephone: 01228 403600</P><P>Fax: 01228 591900</P><P> <P>Animal Pathogens Import Licence <P> <P>The Pathogens Licensing Team <P>Defra <P>Area 5A, Nobel House <P>17 Smith Square,London <P>SW1P 3JR <P>Telephone: 020 7238 6211/6195 <P>Fax: 020 7238 6105 <P>Email:pathogens<sub>d</sub>efra.gsi.gov.uk <P>Website: <a href=\"http://www.defra.gov.uk/animal-diseases/pathogens/\">www.defra.gov.uk/animal-diseases/pathogens/</a>",
+        "formatted_description": "Contact Details for lead Government Department are as follows: <P> <P>Rabies &amp; Hares - Animal Health Certificate Animal - Rabies Pathogens, Hares <P> <P>Animal Health &amp; Veterinary Laboratories Agency</P><P>Hadrian House</P><P>Wavell Drive</P><P>Rosehill</P><P>Carlisle</P><P>CA1 2TB</P><P>Telephone: 01228 403600</P><P>Fax: 01228 591900</P><P> <P>Animal Pathogens Import Licence <P> <P>The Pathogens Licensing Team <P>Defra <P>Area 5A, Nobel House <P>17 Smith Square,London <P>SW1P 3JR <P>Telephone: 020 7238 6211/6195 <P>Fax: 020 7238 6105 <P>Email:pathogens<sub>d</sub>efra.gsi.gov.uk <P>Website: <a href=\"http://www.defra.gov.uk/animal-diseases/pathogens/\">www.defra.gov.uk/animal-diseases/pathogens/</a>"
+      }
+    },
+    {
+      "id": "20085280",
+      "type": "measure",
+      "attributes": {
+        "id": 20085280,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20085280-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "350",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100009",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+            {
+              "id": "20052305",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20052306",
+              "type": "measure_condition"
+            }
+          ]
+        },
+        "measure_components": {
+          "data": [
+
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1011",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+            {
+              "id": "PR003",
+              "type": "footnote"
+            }
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20097824-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "",
+        "formatted_base": ""
+      }
+    },
+    {
+      "id": "750",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Import control of organic products",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "750"
+      }
+    },
+    {
+      "id": "X1906930",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2019-03-26",
+        "regulation_code": "X0693/19",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2019,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20059763",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "C644",
+        "requirement": "Other certificates: Certificate of inspection for organic products",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20059764",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y929",
+        "requirement": "Particular provisions: Goods not concerned by Regulation (EC) No 834/2007 (organic products)",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20059765",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "",
+        "requirement": null,
+        "action": "Import/export not allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "CD808",
+      "type": "footnote",
+      "attributes": {
+        "code": "CD808",
+        "description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br>",
+        "formatted_description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br>"
+      }
+    },
+    {
+      "id": "20097824",
+      "type": "measure",
+      "attributes": {
+        "id": 20097824,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20097824-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "750",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "X1906930",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+            {
+              "id": "20059763",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20059764",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20059765",
+              "type": "measure_condition"
+            }
+          ]
+        },
+        "measure_components": {
+          "data": [
+
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1011",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+            {
+              "id": "CD808",
+              "type": "footnote"
+            }
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20125835-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "142",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      }
+    },
+    {
+      "id": "C2100006",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2021-01-01",
+        "regulation_code": "C0000/21",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20125835-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "1013",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1013",
+        "description": "European Union",
+        "geographical_area_id": "1013"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ES",
+              "type": "geographical_area"
+            },
+            {
+              "id": "EU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SK",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20125835",
+      "type": "measure",
+      "attributes": {
+        "id": 20125835,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20125835-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20125835-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1013",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20079764-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20079764-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "1033",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1033",
+        "description": "CARIFORUM",
+        "geographical_area_id": "1033"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "JM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VC",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20079764",
+      "type": "measure",
+      "attributes": {
+        "id": 20079764,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20079764-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20079764-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1033",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20079859-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20079859-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "1034",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1034",
+        "description": "Eastern and Southern Africa States",
+        "geographical_area_id": "1034"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "MU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZW",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20079859",
+      "type": "measure",
+      "attributes": {
+        "id": 20079859,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20079859-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20079859-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1034",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20079954-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20079954-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "1035",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "1035",
+        "description": "SADC EPA",
+        "geographical_area_id": "1035"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "BW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SZ",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20079954",
+      "type": "measure",
+      "attributes": {
+        "id": 20079954,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20079954-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20079954-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "1035",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20128794-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "C2100002",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2021-01-01",
+        "regulation_code": "C0000/21",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20128794-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "2005",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "2005",
+        "description": "GSP – Least Developed Countries",
+        "geographical_area_id": "2005"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "AO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "CF",
+              "type": "geographical_area"
+            },
+            {
+              "id": "DJ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ER",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ET",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "HT",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LA",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "LS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ML",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MR",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "NP",
+              "type": "geographical_area"
+            },
+            {
+              "id": "RW",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SB",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ST",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TD",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TL",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TV",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TZ",
+              "type": "geographical_area"
+            },
+            {
+              "id": "UG",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VU",
+              "type": "geographical_area"
+            },
+            {
+              "id": "YE",
+              "type": "geographical_area"
+            },
+            {
+              "id": "ZM",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20128794",
+      "type": "measure",
+      "attributes": {
+        "id": 20128794,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20128794-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100002",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20128794-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "2005",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20091260-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20091260-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "2080",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "2080",
+        "description": "OCTs (Overseas Countries and Territories)",
+        "geographical_area_id": "2080"
+      },
+      "relationships": {
+        "children_geographical_areas": {
+          "data": [
+            {
+              "id": "AI",
+              "type": "geographical_area"
+            },
+            {
+              "id": "BM",
+              "type": "geographical_area"
+            },
+            {
+              "id": "FK",
+              "type": "geographical_area"
+            },
+            {
+              "id": "GS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "IO",
+              "type": "geographical_area"
+            },
+            {
+              "id": "KY",
+              "type": "geographical_area"
+            },
+            {
+              "id": "MS",
+              "type": "geographical_area"
+            },
+            {
+              "id": "PN",
+              "type": "geographical_area"
+            },
+            {
+              "id": "SH",
+              "type": "geographical_area"
+            },
+            {
+              "id": "TC",
+              "type": "geographical_area"
+            },
+            {
+              "id": "VG",
+              "type": "geographical_area"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "20091260",
+      "type": "measure",
+      "attributes": {
+        "id": 20091260,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20091260-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20091260-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "2080",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20079669-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20079669-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20079669",
+      "type": "measure",
+      "attributes": {
+        "id": 20079669,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20079669-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20079669-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "CI",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20120631-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20120631-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20120631",
+      "type": "measure",
+      "attributes": {
+        "id": 20120631,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20120631-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20120631-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "CM",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20048852-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20048852-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20048852",
+      "type": "measure",
+      "attributes": {
+        "id": 20048852,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20048852-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20048852-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "CO",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20098274-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "",
+        "formatted_base": ""
+      }
+    },
+    {
+      "id": "20062325",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "C640",
+        "requirement": "Other certificates: Common Health Entry Document for Animals (CHED-A) (as set out in Part 2, Section A of Annex II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261))",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062326",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y072",
+        "requirement": "Particular provisions: Goods with EU origin returning from Andorra, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062327",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y073",
+        "requirement": "Particular provisions: Goods with EU origin returning from Switzerland, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062328",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y074",
+        "requirement": "Particular provisions: Goods with EU origin returning from the Faroe Islands, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062329",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y077",
+        "requirement": "Particular provisions: Goods with EU origin returning from Lichtenstein, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062330",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y078",
+        "requirement": "Particular provisions: Goods with EU origin returning from Norway, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062331",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "Y079",
+        "requirement": "Particular provisions: Goods with EU origin returning from San Marino, according to the relevant EU legislation",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20062332",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "B",
+        "condition": "B: Presentation of a certificate/licence/document",
+        "document_code": "",
+        "requirement": null,
+        "action": "Import/export not allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "CD644",
+      "type": "footnote",
+      "attributes": {
+        "code": "CD644",
+        "description": "Derogations to the presentation of a Common Veterinary Entry Document apply to goods with EU origin returning from certain third countries, according to the relevant EU legislation.",
+        "formatted_description": "Derogations to the presentation of a Common Veterinary Entry Document apply to goods with EU origin returning from certain third countries, according to the relevant EU legislation."
+      }
+    },
+    {
+      "id": "20098274",
+      "type": "measure",
+      "attributes": {
+        "id": 20098274,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20098274-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "410",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100270",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+            {
+              "id": "20062325",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062326",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062327",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062328",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062329",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062330",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062331",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20062332",
+              "type": "measure_condition"
+            }
+          ]
+        },
+        "measure_components": {
+          "data": [
+
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "EU",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+            {
+              "id": "CD625",
+              "type": "footnote"
+            },
+            {
+              "id": "CD644",
+              "type": "footnote"
+            }
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20080049-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20080049-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20080049",
+      "type": "measure",
+      "attributes": {
+        "id": 20080049,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20080049-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20080049-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "FJ",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20056614-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20056614-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20056614",
+      "type": "measure",
+      "attributes": {
+        "id": 20056614,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20056614-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20056614-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "GE",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20072218-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20072218-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20072218",
+      "type": "measure",
+      "attributes": {
+        "id": 20072218,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20072218-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20072218-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "IL",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20090143-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20090143-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20090143",
+      "type": "measure",
+      "attributes": {
+        "id": 20090143,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20090143-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20090143-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "IS",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20109686-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20109686-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20109686",
+      "type": "measure",
+      "attributes": {
+        "id": 20109686,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20109686-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20109686-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "JP",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20079574-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20079574-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20079574",
+      "type": "measure",
+      "attributes": {
+        "id": 20079574,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20079574-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20079574-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "KE",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20064704-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "",
+        "formatted_base": ""
+      }
+    },
+    {
+      "id": "728",
+      "type": "measure_type",
+      "attributes": {
+        "description": "Import control on luxury goods",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "728"
+      }
+    },
+    {
+      "id": "X1904110",
+      "type": "legal_act",
+      "attributes": {
+        "validity_start_date": "2021-01-01T00:00:00.000Z",
+        "validity_end_date": null,
+        "officialjournal_number": "1",
+        "officialjournal_page": 1,
+        "published_date": "2019-03-05",
+        "regulation_code": "X0411/19",
+        "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2019,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+      }
+    },
+    {
+      "id": "20043855",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "Y",
+        "condition": "Y: Other conditions",
+        "document_code": "Y945",
+        "requirement": "Particular provisions: Travellers' personal effects or goods of a non-commercial nature for travellers' personal use contained in their luggage (Art 10.2 of Regulation (EU) 2017/1509)",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20043856",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "Y",
+        "condition": "Y: Other conditions",
+        "document_code": "Y946",
+        "requirement": "Particular provisions: Goods necessary for the official purposes of diplomatic or consular missions of Member States in the DPRK or international organisations enjoying immunities in accordance with international law, or to the personal effects of their staff (Art 10.3 of Regulation (EU) 2017/1509)",
+        "action": "Import/export allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20043857",
+      "type": "measure_condition",
+      "attributes": {
+        "condition_code": "Y",
+        "condition": "Y: Other conditions",
+        "document_code": "",
+        "requirement": null,
+        "action": "Import/export not allowed after control",
+        "duty_expression": "",
+        "condition_duty_amount": null,
+        "condition_monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "condition_measurement_unit_code": null,
+        "condition_measurement_unit_qualifier_code": null
+      },
+      "relationships": {
+        "measure_condition_components": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "20064704",
+      "type": "measure",
+      "attributes": {
+        "id": 20064704,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20064704-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "728",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "X1904110",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+            {
+              "id": "20043855",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20043856",
+              "type": "measure_condition"
+            },
+            {
+              "id": "20043857",
+              "type": "measure_condition"
+            }
+          ]
+        },
+        "measure_components": {
+          "data": [
+
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "KP",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20078146-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20078146-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20078146",
+      "type": "measure",
+      "attributes": {
+        "id": 20078146,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20078146-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20078146-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "KR",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20076129-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20076129-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20076129",
+      "type": "measure",
+      "attributes": {
+        "id": 20076129,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20076129-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20076129-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "LB",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20097204-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20097204-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20097204",
+      "type": "measure",
+      "attributes": {
+        "id": 20097204,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20097204-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20097204-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "MA",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20111079-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20111079-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20111079",
+      "type": "measure",
+      "attributes": {
+        "id": 20111079,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20111079-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20111079-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "MD",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20119671-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20119671-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20119671",
+      "type": "measure",
+      "attributes": {
+        "id": 20119671,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20119671-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20119671-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "MX",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20080334-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20080334-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20080334",
+      "type": "measure",
+      "attributes": {
+        "id": 20080334,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20080334-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20080334-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "PG",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20103771-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20103771-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20103771",
+      "type": "measure",
+      "attributes": {
+        "id": 20103771,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20103771-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20103771-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "SG",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20125947-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20125947-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20125947",
+      "type": "measure",
+      "attributes": {
+        "id": 20125947,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20125947-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20125947-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "SM",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20101931-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20101931-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20101931",
+      "type": "measure",
+      "attributes": {
+        "id": 20101931,
+        "origin": "eu",
+        "effective_start_date": "2021-01-20T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20101931-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20101931-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "TR",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20107012-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20107012-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20107012",
+      "type": "measure",
+      "attributes": {
+        "id": 20107012,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20107012-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20107012-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "VN",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20080239-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20080239-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20080239",
+      "type": "measure",
+      "attributes": {
+        "id": 20080239,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20080239-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20080239-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "WS",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20126145-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20126145-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20126145",
+      "type": "measure",
+      "attributes": {
+        "id": 20126145,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20126145-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20126145-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "XC",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "20126257-duty_expression",
+      "type": "duty_expression",
+      "attributes": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      }
+    },
+    {
+      "id": "20126257-01",
+      "type": "measure_component",
+      "attributes": {
+        "duty_expression_id": "01",
+        "duty_amount": 0.0,
+        "monetary_unit_code": null,
+        "monetary_unit_abbreviation": null,
+        "measurement_unit_code": null,
+        "duty_expression_description": "% or amount",
+        "duty_expression_abbreviation": "%",
+        "measurement_unit_qualifier_code": null
+      }
+    },
+    {
+      "id": "20126257",
+      "type": "measure",
+      "attributes": {
+        "id": 20126257,
+        "origin": "eu",
+        "effective_start_date": "2021-01-01T00:00:00.000Z",
+        "effective_end_date": null,
+        "import": true,
+        "excise": false,
+        "vat": false
+      },
+      "relationships": {
+        "duty_expression": {
+          "data": {
+            "id": "20126257-duty_expression",
+            "type": "duty_expression"
+          }
+        },
+        "measure_type": {
+          "data": {
+            "id": "142",
+            "type": "measure_type"
+          }
+        },
+        "legal_acts": {
+          "data": [
+            {
+              "id": "C2100006",
+              "type": "legal_act"
+            }
+          ]
+        },
+        "measure_conditions": {
+          "data": [
+
+          ]
+        },
+        "measure_components": {
+          "data": [
+            {
+              "id": "20126257-01",
+              "type": "measure_component"
+            }
+          ]
+        },
+        "national_measurement_units": {
+          "data": [
+
+          ]
+        },
+        "geographical_area": {
+          "data": {
+            "id": "XL",
+            "type": "geographical_area"
+          }
+        },
+        "excluded_countries": {
+          "data": [
+
+          ]
+        },
+        "footnotes": {
+          "data": [
+
+          ]
+        },
+        "order_number": {
+          "data": null
+        }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/schemas/commodity.json
+++ b/spec/fixtures/schemas/commodity.json
@@ -1,0 +1,656 @@
+{
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "description": "Generated from parsed.json with shasum c51c8a402e3576d712c045730c0fcf5561858350",
+  "type": "object",
+  "required": true,
+  "properties": {
+    "producline_suffix": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "string",
+      "required": true
+    },
+    "number_indents": {
+      "type": "integer",
+      "required": true
+    },
+    "goods_nomenclature_item_id": {
+      "type": "string",
+      "required": true
+    },
+    "bti_url": {
+      "type": "string",
+      "required": true
+    },
+    "formatted_description": {
+      "type": "string",
+      "required": true
+    },
+    "description_plain": {
+      "type": "string",
+      "required": true
+    },
+    "consigned": {
+      "type": "boolean",
+      "required": true
+    },
+    "consigned_from": {
+    },
+    "basic_duty_rate": {
+      "type": "string",
+      "required": true
+    },
+    "meursing_code": {
+      "type": "boolean",
+      "required": true
+    },
+    "declarable": {
+      "type": "boolean",
+      "required": true
+    },
+    "footnotes": {
+      "type": "array",
+      "required": true,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": true,
+        "properties": {
+          "code": {
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "type": "string",
+            "required": true
+          },
+          "formatted_description": {
+            "type": "string",
+            "required": true
+          }
+        }
+      }
+    },
+    "section": {
+      "type": "object",
+      "required": true,
+      "properties": {
+        "numeral": {
+          "type": "string",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "required": true
+        },
+        "position": {
+          "type": "integer",
+          "required": true
+        },
+        "section_note": {
+          "type": "string",
+          "required": true
+        }
+      }
+    },
+    "chapter": {
+      "type": "object",
+      "required": true,
+      "properties": {
+        "goods_nomenclature_item_id": {
+          "type": "string",
+          "required": true
+        },
+        "description": {
+          "type": "string",
+          "required": true
+        },
+        "formatted_description": {
+          "type": "string",
+          "required": true
+        },
+        "chapter_note": {
+          "type": "string",
+          "required": true
+        },
+        "guides": {
+          "type": "array",
+          "required": true,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "title": {
+                "type": "string",
+                "required": true
+              },
+              "url": {
+                "type": "string",
+                "required": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "heading": {
+      "type": "object",
+      "required": true,
+      "properties": {
+        "goods_nomenclature_item_id": {
+          "type": "string",
+          "required": true
+        },
+        "description": {
+          "type": "string",
+          "required": true
+        },
+        "formatted_description": {
+          "type": "string",
+          "required": true
+        },
+        "description_plain": {
+          "type": "string",
+          "required": true
+        }
+      }
+    },
+    "ancestors": {
+      "type": "array",
+      "required": true,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": true,
+        "properties": {
+          "producline_suffix": {
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "type": "string",
+            "required": true
+          },
+          "number_indents": {
+            "type": "integer",
+            "required": true
+          },
+          "goods_nomenclature_item_id": {
+            "type": "string",
+            "required": true
+          },
+          "formatted_description": {
+            "type": "string",
+            "required": true
+          },
+          "description_plain": {
+            "type": "string",
+            "required": true
+          }
+        }
+      }
+    },
+    "import_measures": {
+      "type": "array",
+      "required": true,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": true,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "required": true
+          },
+          "origin": {
+            "type": "string",
+            "required": true
+          },
+          "effective_start_date": {
+            "type": "string",
+            "required": true
+          },
+          "effective_end_date": {
+          },
+          "import": {
+            "type": "boolean",
+            "required": true
+          },
+          "excise": {
+            "type": "boolean",
+            "required": false
+          },
+          "vat": {
+            "type": "boolean",
+            "required": false
+          },
+          "duty_expression": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "base": {
+                "type": "string",
+                "required": true
+              },
+              "formatted_base": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "measure_type": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "description": {
+                "type": "string",
+                "required": true
+              },
+              "national": {
+              },
+              "measure_type_series_id": {
+                "type": "string",
+                "required": true
+              },
+              "id": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "legal_acts": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "required": true,
+              "properties": {
+                "validity_start_date": {
+                  "type": "string",
+                  "required": true
+                },
+                "validity_end_date": {
+                },
+                "officialjournal_number": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "officialjournal_page": {
+                  "type": ["integer", "null"],
+                  "required": false
+                },
+                "published_date": {
+                  "type": "string",
+                  "required": true
+                },
+                "regulation_code": {
+                  "type": "string",
+                  "required": true
+                },
+                "regulation_url": {
+                  "type": "string",
+                  "required": true
+                }
+              }
+            }
+          },
+          "measure_conditions": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "required": false,
+              "properties": {
+                "condition_code": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "condition": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "document_code": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "requirement": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "action": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "duty_expression": {
+                  "type": ["string", "null"],
+                  "required": false
+                },
+                "condition_duty_amount": {
+                },
+                "condition_monetary_unit_code": {
+                },
+                "monetary_unit_abbreviation": {
+                },
+                "condition_measurement_unit_code": {
+                },
+                "condition_measurement_unit_qualifier_code": {
+                },
+                "measure_condition_components": {
+                  "type": "array",
+                  "required": false,
+                  "uniqueItems": true,
+                  "items": {
+                  }
+                }
+              }
+            }
+          },
+          "measure_components": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "national_measurement_units": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "geographical_area": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "id": {
+                "type": "string",
+                "required": true
+              },
+              "description": {
+                "type": "string",
+                "required": true
+              },
+              "geographical_area_id": {
+                "type": "string",
+                "required": true
+              },
+              "children_geographical_areas": {
+                "type": "array",
+                "required": false,
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": true,
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "required": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "required": true
+                    },
+                    "geographical_area_id": {
+                      "type": "string",
+                      "required": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "excluded_countries": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "footnotes": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "required": true,
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "required": true
+                },
+                "description": {
+                  "type": "string",
+                  "required": true
+                },
+                "formatted_description": {
+                  "type": "string",
+                  "required": true
+                }
+              }
+            }
+          },
+          "order_number": {
+          }
+        }
+      }
+    },
+    "export_measures": {
+      "type": "array",
+      "required": true,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": true,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "required": true
+          },
+          "origin": {
+            "type": "string",
+            "required": true
+          },
+          "effective_start_date": {
+            "type": "string",
+            "required": true
+          },
+          "effective_end_date": {
+          },
+          "import": {
+            "type": "boolean",
+            "required": true
+          },
+          "excise": {
+            "type": "boolean",
+            "required": false
+          },
+          "vat": {
+            "type": "boolean",
+            "required": false
+          },
+          "duty_expression": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "base": {
+                "type": "string",
+                "required": true
+              },
+              "formatted_base": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "measure_type": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "description": {
+                "type": "string",
+                "required": true
+              },
+              "national": {
+              },
+              "measure_type_series_id": {
+                "type": "string",
+                "required": true
+              },
+              "id": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "legal_acts": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "required": true,
+              "properties": {
+                "validity_start_date": {
+                  "type": "string",
+                  "required": true
+                },
+                "validity_end_date": {
+                },
+                "officialjournal_number": {
+                  "type": "string",
+                  "required": true
+                },
+                "officialjournal_page": {
+                },
+                "published_date": {
+                  "type": "string",
+                  "required": true
+                },
+                "regulation_code": {
+                  "type": "string",
+                  "required": true
+                },
+                "regulation_url": {
+                  "type": "string",
+                  "required": true
+                }
+              }
+            }
+          },
+          "measure_conditions": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "measure_components": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "required": true,
+              "properties": {
+                "duty_expression_id": {
+                  "type": "string",
+                  "required": true
+                },
+                "duty_amount": {
+                },
+                "monetary_unit_code": {
+                },
+                "monetary_unit_abbreviation": {
+                },
+                "measurement_unit_code": {
+                  "type": "string",
+                  "required": true
+                },
+                "duty_expression_description": {
+                  "type": "string",
+                  "required": true
+                },
+                "duty_expression_abbreviation": {
+                  "type": "string",
+                  "required": true
+                },
+                "measurement_unit_qualifier_code": {
+                }
+              }
+            }
+          },
+          "national_measurement_units": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "geographical_area": {
+            "type": "object",
+            "required": true,
+            "properties": {
+              "id": {
+                "type": "string",
+                "required": true
+              },
+              "description": {
+                "type": "string",
+                "required": true
+              },
+              "geographical_area_id": {
+                "type": "string",
+                "required": true
+              },
+              "children_geographical_areas": {
+                "type": "array",
+                "required": true,
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": true,
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "required": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "required": true
+                    },
+                    "geographical_area_id": {
+                      "type": "string",
+                      "required": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "excluded_countries": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "footnotes": {
+            "type": "array",
+            "required": true,
+            "uniqueItems": true,
+            "items": {
+            }
+          },
+          "order_number": {
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -7,15 +7,26 @@ RSpec.describe Uktt::Http do
   let(:debug) { false }
   let(:conn) { double }
   let(:response) { double }
+  let(:parser) { double(parse: {}) }
+  let(:host) { 'http://localhost' }
 
   describe '#retrieve' do
     before do
       allow(conn).to receive(:get).and_return(response)
       allow(response).to receive(:body).and_return('{}')
+      allow(Uktt::Parser).to receive(:new).and_return(parser)
     end
 
     let(:expected_headers) { { 'Content-Type' => 'application/json' } }
     let(:expected_body) { {} } 
+
+
+    it 'passes the body and format to the Parser' do
+      client.retrieve('commodities/1234567890')
+
+      expect(Uktt::Parser).to have_received(:new).with('{}', 'ostruct')
+    end
+
 
     context 'when the host includes xi in the path' do
       let(:host) { 'http://localhost/xi' }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Uktt::Parser do
+  subject(:parser) { described_class.new(body, format) }
+
+  let(:body) { read_file('commodity.json') }
+
+  context 'when parsing to ostruct' do
+    let(:format) { 'ostruct' }
+
+    it 'returns valid OpenStruct' do
+      expect(parser.parse).to be_a(OpenStruct)
+    end
+  end
+
+  context 'when parsing to json' do
+    let(:format) { 'json' }
+
+    it 'returns valid raw json' do
+      expect(parser.parse).to eq(body)
+    end
+  end
+
+  context 'when parsing to jsonapi' do
+    let(:format) { 'jsonapi' }
+    let(:schema) { parse_file('schemas/commodity.json') }
+
+    it 'returns valid jsonapi' do
+      parsed = parser.parse
+      valid = JSON::Validator.validate(schema, parsed)
+      expect(valid).to be(true)
+    end
+  end
+
+  context 'when parsing to an unknown format' do
+    let(:format) { 'foo' }
+
+    it 'propagates an error' do
+      expect { parser.parse }.to raise_error(ArgumentError, 'Specified invalid format foo')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'uktt'
+require 'json-schema'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -23,4 +24,18 @@ end
 
 def api_host
   Uktt::Http.api_host
+end
+
+
+def read_file(fixture)
+  fixture_path = "spec/fixtures"
+  path = File.join(fixture_path, fixture)
+
+  File.read(path)
+end
+
+def parse_file(fixture)
+  file = read_file(fixture)
+
+  JSON.parse(file)
 end

--- a/spec/uktt_api_spec.rb
+++ b/spec/uktt_api_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   opts = {host: api_host, 
           version: spec_version, 
           debug: false,
-          return_json: false}
+          format: 'ostruct'}
 
   section_id = '1'
   section = Uktt::Section.new(opts.merge(section_id: section_id))
@@ -30,7 +30,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   }
 
   it 'retrieves one section as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = section.retrieve
 
     expect(response).to be_an_instance_of(OpenStruct)
@@ -43,7 +43,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one section as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(section.retrieve, symbolize_names: true)
 
     expect(response).to be_an_instance_of(Hash)
@@ -56,7 +56,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one section\'s note as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = section.note
 
     expect(response).to be_an_instance_of(OpenStruct)
@@ -69,7 +69,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one section\'s note as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(section.note, symbolize_names: true)
 
     expect(response).to be_an_instance_of(Hash)
@@ -82,7 +82,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves all sections as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = section.retrieve_all
 
     case spec_version
@@ -98,7 +98,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves all sections as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(section.retrieve_all, symbolize_names: true)
 
     case spec_version
@@ -112,7 +112,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one chapter as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = chapter.retrieve
 
     case spec_version
@@ -126,7 +126,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one chapter as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(chapter.retrieve, symbolize_names: true)
 
     case spec_version
@@ -140,7 +140,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
   
   it 'retrieves one chapter\'s note as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = chapter.note
 
     expect(response).to be_an_instance_of(OpenStruct)
@@ -155,7 +155,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one chapter\'s note as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(chapter.note, symbolize_names: true)
 
     case spec_version
@@ -169,7 +169,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one chapter\'s changes as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = chapter.changes
     case spec_version
     when 'v1'
@@ -182,7 +182,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one chapter\'s changes as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(chapter.changes, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -195,7 +195,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves all chapters as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = chapter.retrieve_all
     case spec_version
     when 'v1'
@@ -210,7 +210,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves all chapters as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(chapter.retrieve_all, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -223,7 +223,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one heading as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = heading.retrieve
     case spec_version
     when 'v1'
@@ -236,7 +236,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one heading as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(heading.retrieve, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -249,7 +249,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one heading\'s changes as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = heading.changes
     case spec_version
     when 'v1'
@@ -262,7 +262,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one heading\'s changes as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(heading.changes, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -275,7 +275,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one commodity as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = commodity.retrieve
     case spec_version
     when 'v1'
@@ -288,7 +288,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one commodity as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(commodity.retrieve, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -301,7 +301,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one commodity\'s changes as OpenStruct' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = commodity.changes
     case spec_version
     when 'v1'
@@ -314,7 +314,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves one commodity\'s changes as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(chapter.changes, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -327,7 +327,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves monetary exchange rates as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     response = monetary_exchange_rate.retrieve_all
     case spec_version
     when 'v1'
@@ -342,7 +342,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves monetary exchange rates as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     response = JSON.parse(monetary_exchange_rate.retrieve_all, symbolize_names: true)
     case spec_version
     when 'v1'
@@ -357,7 +357,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a heading as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     case spec_version
     when 'v2'
       response = heading.goods_nomenclatures
@@ -369,7 +369,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a heading as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     case spec_version
     when 'v2'
       response = JSON.parse(heading.goods_nomenclatures, symbolize_names: true)
@@ -380,7 +380,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a chapter as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     case spec_version
     when 'v2'
       response = chapter.goods_nomenclatures
@@ -392,7 +392,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a chapter as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     case spec_version
     when 'v2'
       response = JSON.parse(chapter.goods_nomenclatures, symbolize_names: true)
@@ -403,7 +403,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a section as [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     case spec_version
     when 'v2'
       response = section.goods_nomenclatures
@@ -415,7 +415,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'retrieves goods nomenclatures for a section as JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     case spec_version
     when 'v2'
       response = JSON.parse(section.goods_nomenclatures, symbolize_names: true)
@@ -426,7 +426,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'performs a search and returns [OpenStructs]' do
-    Uktt.configure(return_json: false, version: spec_version)
+    Uktt.configure(format: 'ostruct', version: spec_version)
     case spec_version
     when 'v2'
       response = quota.search(quota_search_params)
@@ -436,7 +436,7 @@ RSpec.describe 'UK Trade Tariff API client' do
   end
 
   it 'performs a search and returns JSON' do
-    Uktt.configure(return_json: true, version: spec_version)
+    Uktt.configure(format: 'json', version: spec_version)
     case spec_version
     when 'v2'
       response = JSON.parse(quota.search(quota_search_params), symbolize_names: true)

--- a/spec/uktt_spec.rb
+++ b/spec/uktt_spec.rb
@@ -3,7 +3,7 @@ require 'uktt'
 RSpec.describe 'UK Trade Tariff gem' do
   host = Uktt::API_HOST_PROD
 
-  test_opts = {format: false, 
+  test_opts = {format: 'ostruct', 
                host: api_host, 
                version: spec_version,
                debug: false,
@@ -11,7 +11,7 @@ RSpec.describe 'UK Trade Tariff gem' do
 
   new_opts = {host: host,
               version: 'v2',
-              format: true,
+              format: 'json',
               debug: true,
               currency: Uktt::PARENT_CURRENCY}
 

--- a/spec/uktt_spec.rb
+++ b/spec/uktt_spec.rb
@@ -3,7 +3,7 @@ require 'uktt'
 RSpec.describe 'UK Trade Tariff gem' do
   host = Uktt::API_HOST_PROD
 
-  test_opts = {return_json: false, 
+  test_opts = {format: false, 
                host: api_host, 
                version: spec_version,
                debug: false,
@@ -11,7 +11,7 @@ RSpec.describe 'UK Trade Tariff gem' do
 
   new_opts = {host: host,
               version: 'v2',
-              return_json: true,
+              format: true,
               debug: true,
               currency: Uktt::PARENT_CURRENCY}
 

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'json-schema'
 end

--- a/uktt.yaml
+++ b/uktt.yaml
@@ -1,5 +1,5 @@
 ---
-  host: http://localhost:3002
-  version: v1
+  host: https://dev.trade-tariff.service.gov.uk/api
+  version: v2
   debug: false
-  return_json: false
+  format: ostruct


### PR DESCRIPTION
**Jira link**

https://transformuk.atlassian.net/browse/HOTT-467

**What**

- [x] Support `format` instead of `return_json` as an config option
- [x] Add parser that orchestrates the handling of the format option and the response document
- [x] Adds integration specs that do a full schema validation of all nested resources being returned by the json api parser.
- [x] Adds a spec to the client to make sure we're calling the parser with the correct args

**Why**

- We want the client to do more of the heavy lifting when it comes to deserializing json api documents.
- Available clients written for json:api won't work with our codebase since we use non-compliant json api.
- I specifically want this so that I can pull out related measure components on import measures and understand the different units for the calculator inputs

**AC**

- Preserves the default behaviour of deserializing json to OpenStruct